### PR TITLE
FEI-4042: Don't bother generating sourcemaps

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -47,7 +47,12 @@ module.exports.flowPlugin = function flowPlugin(options = {
         const transformed = flowRemoveTypes(src, options.flow);
         return {
           code: transformed.toString(),
-          map: transformed.generateMap(),
+          // flow-remove-types sets sources to ['source.js'].  This is no configurable.
+          // As a result all transpiled files map to the same file which is confusing.
+          // Fixing this for real would require making hcanges to flow-remove-types itself.
+          // Since ViteJS's transpilation changes are minimal, debugging the code it outputs
+          // it is good enough for now.
+          map: null,
         };
       }
     },

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -7,7 +7,7 @@ const { readFile } = require('fs');
 type VitePlugin = {
   enforce: string,
   name: string | RegExp,
-  transform: (string, string) => (void | { code: string, map: string })
+  transform: (string, string) => (void | { code: string, map: string | null })
 };
 
 type VitePluginOptions = {
@@ -91,7 +91,12 @@ module.exports.flowPlugin = function flowPlugin(options: VitePluginOptions = {
         const transformed = flowRemoveTypes(src, options.flow);
         return {
           code: transformed.toString(),
-          map: transformed.generateMap(),
+          // flow-remove-types sets sources to ['source.js'].  This is no configurable.
+          // As a result all transpiled files map to the same file which is confusing.
+          // Fixing this for real would require making hcanges to flow-remove-types itself.
+          // Since ViteJS's transpilation changes are minimal, debugging the code it outputs
+          // it is good enough for now.
+          map: null,
         };
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const { readFile } = require('fs');
 type VitePlugin = {
   enforce: string,
   name: string | RegExp,
-  transform: (string, string) => (void | { code: string, map: string })
+  transform: (string, string) => (void | { code: string, map: string | null })
 };
 
 type VitePluginOptions = {
@@ -91,7 +91,12 @@ module.exports.flowPlugin = function flowPlugin(options: VitePluginOptions = {
         const transformed = flowRemoveTypes(src, options.flow);
         return {
           code: transformed.toString(),
-          map: transformed.generateMap(),
+          // flow-remove-types sets sources to ['source.js'].  This is no configurable.
+          // As a result all transpiled files map to the same file which is confusing.
+          // Fixing this for real would require making hcanges to flow-remove-types itself.
+          // Since ViteJS's transpilation changes are minimal, debugging the code it outputs
+          // it is good enough for now.
+          map: null,
         };
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,11 +153,6 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-plugin-utils@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
-  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
-
 "@babel/helper-replace-supers@^7.13.12":
   version "7.13.12"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
@@ -254,21 +249,6 @@
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
   integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
-
-"@babel/plugin-syntax-flow@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz#2ff654999497d7d7d142493260005263731da180"
-  integrity sha512-9WK5ZwKCdWHxVuU13XNT6X73FGmutAXeor5lGFq6qhOFtMFUF4jkbijuyUdZZlpYq6E2hZeZf/u3959X9wsv0Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-
-"@babel/plugin-transform-flow-strip-types@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.14.5.tgz#0dc9c1d11dcdc873417903d6df4bed019ef0f85e"
-  integrity sha512-KhcolBKfXbvjwI3TV7r7TkYm8oNXHNBqGOy6JDVwtecFaRoKYsUUqJdS10q0YDKW1c6aZQgO+Ys3LfGkox8pXA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/plugin-syntax-flow" "^7.14.5"
 
 "@babel/runtime-corejs3@^7.10.2":
   version "7.14.0"
@@ -2533,17 +2513,17 @@ flow-copy-source@^2.0.9:
     kefir "^3.7.3"
     yargs "^15.0.1"
 
-flow-parser@^0.153.0:
-  version "0.153.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.153.0.tgz#bac7e977c79f380b07088d36fd0fccea24435db8"
-  integrity sha512-qa7UODgbofQyruRWqNQ+KM5hO37CenByxhNfAztiwjBsPhWZ5AFh5g+gtLpTWPlzG7X66QdjBB9DuHNUBcaF+Q==
+flow-parser@^0.162.0:
+  version "0.162.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.162.0.tgz#bd5317f71b38a71900979fa47528b68aeef099d1"
+  integrity sha512-tqn7GkffCpBkGl6cFPHk08gug2Gb+KgE4ShDJmYVUFAARKvwtgxiLbLk2pv22KMLtzin+OPeCku3UoBE66nQDg==
 
-flow-remove-types@^2.153.0:
-  version "2.153.0"
-  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.153.0.tgz#5b97b6a32bd729112a3e2cd474e46d6a9bdad3aa"
-  integrity sha512-KHl0r0xH5VBMOtKmk2WJME3F4UDg+j0f/yH6lbBIGk3xKl5NTHLs+1h9murH9+KLxvVZ0ut5ydd/fx49RSqmEw==
+flow-remove-types@^2.158.0:
+  version "2.162.0"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.162.0.tgz#edae906f87afdbd6ae100e133e6c6c074e7a7896"
+  integrity sha512-MZxBuutqo8fnppmehSAxVi01C52mwfs7KQDkaSLN+LIgLtqqrE0RgY4tx2xLeMD/0ZwEg3yrucBLl9o/OCIrhw==
   dependencies:
-    flow-parser "^0.153.0"
+    flow-parser "^0.162.0"
     pirates "^3.0.2"
     vlq "^0.2.1"
 


### PR DESCRIPTION
## Summary:
The code that ViteJS (via esbuild) outputs is easy enough to debug without sourcemaps and properly fixing sourcemaps will required modifying flow-remove-types.  Doing so probably isn't worth the effort, but if we really want to we can do this later by vendoring in flow-remove-types.

Issue: FEI-4042

## Test plan:
- I've made this change locally within services/static/node_modules/@bunchtogether/vite-plugin-flow when prototyping a ViteJS setup